### PR TITLE
Added dependency with jquery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /nbproject/
 /.idea
 /node_modules/
+/bower_components/

--- a/bower.json
+++ b/bower.json
@@ -31,5 +31,8 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "dependencies": {
+    "jquery": "^1.11"
+  }
 }


### PR DESCRIPTION
The dependency with jquery 1.11+ was included on bower.json. I hadn't included the dependency with font-awesome as mentioned in issue #9 since I understand that lobibox can use font-awesome, but not have to use that, which turns font-awesome an optional dependency (not supported by bower). 

However, if you think that this relation could be made, I can include a new commit with this modification.

Thanks.
